### PR TITLE
feature/options-obj

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ angular
 .module('app', ['ngSimditor'])
 .config(function($provide) {
 
-  // simditor options customize
+  // simditor global options customize
   $provide.decorator('simditorOptions', ['$delegate', function(simditorOptions) {
     simditorOptions.toolbar = [
       'title',
@@ -55,8 +55,12 @@ angular
 
 ```html
 <simditor ng-model="content" placeholder="hahahahah"></simditor>
+
+<!-- OR -->
+
+<simditor ng-model="content" options="{placeholder:'hahahahah',...}"></simditor>
 ```
 
-## Opttions
+## Options
 
-check more [Options](http://simditor.tower.im/docs/doc-config.html#anchor-toolbarFloat) for ng-simditor.
+Check more [Options](http://simditor.tower.im/docs/doc-config.html#anchor-toolbarFloat) for ng-simditor.

--- a/dist/js/ng-simditor.js
+++ b/dist/js/ng-simditor.js
@@ -14,15 +14,24 @@ function simditor(simditorOptions) {
   return {
     restrict: 'AE',
     require: 'ngModel',
+    scope: {
+      options: '<'
+    },
     link: function link(scope, element, attr, ngModel) {
       if (!ngModel) return;
 
-      var $textarea = angular.element('<textarea placeholder="' + attr.placeholder + '"></textarea>');
+      var options = scope.options || {};
+
+      if (attr.placeholder != null) {
+        options.placeholder = attr.placeholder;
+      }
+
+      var $textarea = angular.element('<textarea></textarea>');
       element.append($textarea);
 
       var config = angular.extend({
         textarea: $textarea
-      }, simditorOptions);
+      }, simditorOptions, options);
 
       var editor = new Simditor(config);
 

--- a/package.json
+++ b/package.json
@@ -21,14 +21,14 @@
   },
   "homepage": "https://github.com/forsigner/ng-simditor#readme",
   "devDependencies": {
+    "babelify": "^6.3.0",
     "browserify": "^11.2.0",
+    "gulp": "^3.9.1",
     "gulp-less": "^3.0.3",
     "gulp-minify-css": "^1.2.1",
     "gulp-rename": "^1.2.2",
     "gulp-uglify": "^1.4.1",
-    "vinyl-source-stream": "^1.1.0",
-    "babelify": "^6.3.0"
+    "vinyl-source-stream": "^1.1.0"
   },
-  "dependencies": {
-  }
+  "dependencies": {}
 }

--- a/src/js/simditor.directive.js
+++ b/src/js/simditor.directive.js
@@ -8,15 +8,24 @@ function simditor(simditorOptions) {
   return {
     restrict: 'AE',
     require: 'ngModel',
+    scope: {
+      options: '<'
+    },
     link: function(scope, element, attr, ngModel) {
       if (!ngModel) return;
 
-      var $textarea = angular.element('<textarea placeholder="' + attr.placeholder + '"></textarea>');
+      var options = scope.options || {};
+
+      if (attr.placeholder != null) {
+        options.placeholder = attr.placeholder;
+      }
+
+      var $textarea = angular.element('<textarea></textarea>');
       element.append($textarea);
 
       var config = angular.extend({
         textarea: $textarea
-      }, simditorOptions);
+      }, simditorOptions, options);
 
       var editor = new Simditor(config);
 


### PR DESCRIPTION
This adds a way to pass an entire options object to ng-simditor to override the `simditorOptions` service. It sill allows the current way of just passing the placeholder, too.

Example of passing options object:
```html
<simditor ng-model="content" options="{placeholder:'My value', etc...}"></simditor>
```